### PR TITLE
modelsummary 1.4.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ Suggests:
     sandwich,
     testthat,
     modelsummary,
+    gt,
     ggplot2
 Encoding: UTF-8
 LazyData: true

--- a/vignettes/ivreg.Rmd
+++ b/vignettes/ivreg.Rmd
@@ -17,6 +17,7 @@ vignette: >
 
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = TRUE, fig.height=4, fig.width=4)
+options(modelsummary_factory_default = "gt")
 ```
 
 ## Overview


### PR DESCRIPTION
`kableExtra` does not appear to be actively maintained and it causes some problems on `pkgdown` websites and for installation on some platforms. In version 1.4.0, `modelsummary` will no longer depend on `kableExtra`. Instead it will give the user a choice to install any of the supported table-making package, and offer a function to set a persistent default.

Call setting:

```r
modelsummary(model, output = "gt")
```

Persistent setting stays only for the current session:

```r
options(modelsummary_factory_default = "gt")
```

Persistent setting stays across sessions:

```r
config_modelsummary(factory_default = "gt")
```

Developers of packages that use `modelsummary` in vignettes need to add a table-making package to `Suggests`.

